### PR TITLE
тушит неактивные ссылки

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+## CSS
+
+Мы используем [БЭМ](https://ru.bem.info/methodology/quick-start/)
+
+```css
+.block
+.block--modifier
+.block__element
+.block__element--modifier
+```
+
+```html
+<div class="mail-user">
+    <div class="mail-user__container">
+        <div class="mail-user__name user-red">
+            <span class="user-red__letter">h</span><span class="user-red__other">igimo</span>
+        </div>
+        <span class="mail-user__avatar">
+            <img src="//design.ru.net/200.jpg" />
+        </span>
+    </div>
+</div>
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## CSS
 
-Мы используем [БЭМ](https://ru.bem.info/methodology/quick-start/)
+Мы используем [БЭМ](https://ru.bem.info/methodology/quick-start/) в международной нотации:
 
 ```css
 .block
@@ -9,15 +9,4 @@
 .block__element--modifier
 ```
 
-```html
-<div class="mail-user">
-    <div class="mail-user__container">
-        <div class="mail-user__name user-red">
-            <span class="user-red__letter">h</span><span class="user-red__other">igimo</span>
-        </div>
-        <span class="mail-user__avatar">
-            <img src="//design.ru.net/200.jpg" />
-        </span>
-    </div>
-</div>
-```
+Элементы обозначаются `__`, модификаторы `--`, схема ключ-значение в модификаторах не используется.

--- a/src/includes/footer.njk
+++ b/src/includes/footer.njk
@@ -3,12 +3,12 @@
         Веб-стандарты, 2006–2019
     </p>
     <ul class="footer__pages">
-        <li><a class="footer__link" href="">Статьи</a></li>
-        <li><a class="footer__link">Конференция</a></li>
-        <li><a class="footer__link">Календарь</a></li>
-        <li><a class="footer__link">Подкаст</a></li>
-        <li><a class="footer__link" href="">О проекте</a></li>
-        <li><a class="footer__link" href="">Поддержать проект</a></li>
+        <li><a class="footer__link" href="/articles/">Статьи</a></li>
+        <li><a class="footer__link footer__link--disable">Конференция</a></li>
+        <li><a class="footer__link footer__link--disable">Календарь</a></li>
+        <li><a class="footer__link footer__link--disable">Подкаст</a></li>
+        <li><a class="footer__link footer__link--disable">О проекте</a></li>
+        <li><a class="footer__link footer__link--disable">Поддержать проект</a></li>
     </ul>
     <p class="footer__design">
         Дизайн сайта: <a class="footer__link" href="">Игорь Штанг</a>

--- a/src/includes/header.njk
+++ b/src/includes/header.njk
@@ -12,11 +12,11 @@
         <button class="navigation__button" type="button"></button>
         <ul class="navigation__pages">
             <li class="navigation__page"><a class="navigation__link" href="/articles/">Статьи</a></li>
-            <li class="navigation__page"><a class="navigation__link">Конференция</a></li>
-            <li class="navigation__page"><a class="navigation__link">Календарь</a></li>
-            <li class="navigation__page"><a class="navigation__link">Подкаст</a></li>
-            <li class="navigation__page"><a class="navigation__link" href="">О проекте</a></li>
-            <li class="navigation__page navigation__page--right"><a class="navigation__link" href="">Поддержать проект</a></li>
+            <li class="navigation__page"><a class="navigation__link navigation__link--disable">Конференция</a></li>
+            <li class="navigation__page"><a class="navigation__link navigation__link--disable">Календарь</a></li>
+            <li class="navigation__page"><a class="navigation__link navigation__link--disable">Подкаст</a></li>
+            <li class="navigation__page"><a class="navigation__link navigation__link--disable">О проекте</a></li>
+            <li class="navigation__page navigation__page--right"><a class="navigation__link navigation__link--disable">Поддержать проект</a></li>
         </ul>
     </nav>
     <ul class="header__informer informer">

--- a/src/styles/blocks/navigation.css
+++ b/src/styles/blocks/navigation.css
@@ -55,3 +55,7 @@
 .navigation__link:visited {
     color: inherit;
 }
+
+.navigation__link--disable {
+    opacity: .5;
+}


### PR DESCRIPTION
В футере неактивные ссылки красиво потушены:

![Screenshot_10](https://user-images.githubusercontent.com/2804205/67231398-eac2c880-f447-11e9-89fd-73c386cd9cb4.png)

Предлагаю потушить ссылки и в верхнем меню:
![Screenshot_11](https://user-images.githubusercontent.com/2804205/67231399-eac2c880-f447-11e9-92b8-b01be4417de4.png)
