### PR TITLE
Правит опечатку в тэге

### DIFF
--- a/src/layouts/article.njk
+++ b/src/layouts/article.njk
@@ -65,7 +65,7 @@ layout: page.njk
         <div class="article__content content">
             {{ content | safe }}
         </div>
-    </address>
+    </div>
 </main>
 
 {% include 'aside.njk' %}


### PR DESCRIPTION
В article.njk попалась опечатка, видимо редактор кода автоматически сменил закрывающий тег, а дальше что-то пошло не так :)