### PR TITLE
Карточка статьи. Текст статьи

### DIFF
--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -64,7 +64,8 @@
 .content ol,
 .content ul {
     list-style: none;
-    margin: 16px 0;
+    margin-top: 16px;
+    margin-bottom: 16px;
     padding-left: 0;
 }
 
@@ -123,15 +124,12 @@
     height: auto;
 }
 
-.content figure {
-    margin: 32px 0;
-}
-
 /* Цитаты */
 
 .content blockquote {
     position: relative;
-    margin: 16px 0;
+    margin-top: 16px;
+    margin-bottom: 16px;
     padding: 5px 0;
     padding-left: 14px;
     font-size: 18px;
@@ -153,7 +151,8 @@
 
 .content pre {
     position: relative;
-    margin: 16px 0;
+    margin-top: 16px;
+    margin-bottom: 16px;
     padding: 4px 16px;
     background-color: var(--color-green-light);
     background-image: linear-gradient(
@@ -221,10 +220,10 @@
         font-size: 21px;
     }
 
-    .content.content > * {
-        /* не хватает специфичности, чтобы перебить маргины у элементов */
+    .content > * {
         width: var(--content-width);
         margin-left: auto;
+        margin-right: 0;
     }
 
     .content h2,
@@ -240,6 +239,12 @@
 
     .content a {
         text-decoration: underline;
+    }
+
+    .content ol,
+    .content ul {
+        margin-top: 32px;
+        margin-bottom: 32px;
     }
 
     .content ol > li,
@@ -258,46 +263,6 @@
 
     /* Картинки */
 
-    /* Подпись в левой колонке */
-
-    .content .content__media--floated-caption {
-        display: flex;
-        width: 100%;
-    }
-
-    .content__media--floated-caption img {
-        max-width: var(--content-width);
-    }
-
-    .content__media--floated-caption figcaption {
-        order: -1;
-        max-width: 300px;
-        margin-right: auto;
-    }
-
-    /* Картинки с обтеканием текста */
-
-    .content .content__media--align-right {
-        width: var(--content-half);
-        float: right;
-        margin-left: 1em;
-    }
-
-    /* .content__media--align-right + * {
-        clear: both;
-    } */
-
-    /* Картинки на всю ширину */
-
-    .content .content__media--full {
-        width: 100%;
-    }
-
-    .content__media--full figcaption {
-        width: var(--content-width);
-        margin-left: auto;
-    }
-
     .content blockquote {
         margin-top: 40px;
         margin-bottom: 60px;
@@ -312,7 +277,8 @@
     }
 
     .content pre {
-        margin: 60px 0;
+        margin-top: 60px;
+        margin-bottom: 60px;
         padding-left: 36px;
     }
 

--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -1,8 +1,53 @@
 /* Content */
 
-.content img {
-    max-width: 100%;
-    height: auto;
+.content {
+    --list-marker-color: var(--color-grey-lighter);
+
+    --image-caption-color: var(--color-grey-darker);
+
+    --code-bg-gradient-left: var(--color-green-light);
+    --code-bg-gradient-right: #def3f6;
+    --code-overflow-gradient-left: transparent;
+    --code-overflow-gradient-right: #dff3f4;
+    --code-scrollbar-color: #a3cfd1;
+    font-size: 12px;
+    line-height: 1.7;
+    color: black;
+}
+
+.content h2,
+.content h3 {
+    margin-top: 32px;
+    margin-bottom: 16px;
+    font-size: 16px;
+    line-height: 1.2;
+    font-family: 'Dewi Expanded', sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.content h3 {
+    font-size: 14px;
+}
+
+.content h2 code,
+.content h3 code {
+    /* fixes default monospace font */
+    font-family: inherit;
+}
+
+.content p {
+    margin-top: 1em;
+    margin-bottom: 0;
+}
+
+.content p:first-child {
+    margin-top: 0;
+}
+
+.content a {
+    color: #0064a4;
+    text-decoration: none;
 }
 
 .content a:link {
@@ -18,6 +63,206 @@
 .content a:active {
     color: var(--color-turquoise);
 }
+
+/* Lists
+    '>' selector fixes nested lists
+*/
+
+.content ol,
+.content ul {
+    list-style: none;
+    margin: 16px 0;
+    padding-left: 0;
+}
+
+.content li {
+    position: relative;
+    margin-top: 16px;
+}
+
+/* Unordered Lists */
+
+.content ul > li {
+    padding-left: 37px;
+}
+
+.content ul > li::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0.5em;
+    width: 14px;
+    height: 2px;
+    background-color: var(--list-marker-color);
+}
+
+/* Ordered Lists */
+
+.content ol {
+    counter-reset: list;
+}
+
+.content ol > li {
+    padding-left: 24px;
+}
+
+.content ol > li::before {
+    counter-increment: list;
+    content: counter(list);
+    position: absolute;
+    left: 0;
+    top: 0;
+    font-size: 21px;
+    font-weight: bold;
+    line-height: 1.2;
+    color: var(--list-marker-color);
+}
+
+/* Картинки */
+
+.content img {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+
+    /* set margin for imgs, which doesnt have figure wrapper */
+    margin-top: 16px;
+}
+
+.content img + em,
+.content figcaption {
+    display: block;
+    margin-top: 8px;
+    font-size: 10px;
+    line-height: 1.7;
+    font-style: normal;
+    color: var(--image-caption-color);
+}
+
+.content figure,
+.content .content__image {
+    margin: 0;
+    margin: 32px 0;
+}
+
+.content figure img {
+    /* reset margin when img has figure around it */
+    margin: 0;
+}
+
+/* Increase specificity */
+
+/* .content .content__image--full {
+} */
+
+.content .content__image--align-left,
+.content .content__image--align-right {
+    margin: 16px 0;
+}
+
+/* Цитаты */
+
+.content blockquote {
+    position: relative;
+    margin: 16px 0;
+    padding: 5px 0;
+    padding-left: 14px;
+    font-size: 18px;
+    line-height: 1.7;
+    color: black;
+}
+
+.content blockquote::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background-color: var(--color-grey-lighter);
+}
+
+.content blockquote h1 {
+    margin: 0;
+    font-size: inherit;
+    font-weight: inherit;
+    color: inherit;
+}
+
+/* Код */
+
+.content pre {
+    position: relative;
+    margin: 16px 0;
+    padding: 4px 16px;
+    background-color: var(--code-bg-gradient-left);
+    background-image: linear-gradient(
+        to right,
+        var(--code-bg-gradient-left) 0%,
+        var(--code-bg-gradient-right) 100%
+    );
+}
+
+.content pre::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: 76px;
+    background-image: linear-gradient(
+        to left,
+        var(--code-overflow-gradient-right) 0%,
+        var(--code-overflow-gradient-left) 100%
+    );
+}
+
+.content pre code {
+    display: block;
+    padding: 16px 0;
+    overflow: auto;
+}
+
+.content code::-webkit-scrollbar {
+    height: 3px;
+}
+
+.content code::-webkit-scrollbar-thumb {
+    background-color: var(--code-scrollbar-color);
+    border-radius: 24px;
+}
+
+.content iframe {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin: 0;
+    margin-top: 16px;
+    border: 0;
+}
+
+/* Буквица */
+
+.content > p:first-of-type::first-letter {
+    font-family: 'Dewi Expanded';
+    color: var(--color-grey-medium);
+}
+
+/* @supports (-webkit-initial-letter: 2) or (initial-letter: 2) {
+    .content > p:first-of-type {
+        initial-letter: 2;
+    }
+} */
+
+@supports not ((-webkit-initial-letter: 2) or (initial-letter: 2)) {
+    .content > p:first-of-type::first-letter {
+        float: left;
+        padding: 0 5px;
+        font-size: 2em;
+    }
+}
+
 
 @media (min-width: 1240px) {
     .content {

--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -1,15 +1,6 @@
 /* Content */
 
 .content {
-    --list-marker-color: var(--color-grey-lighter);
-
-    --image-caption-color: var(--color-grey-darker);
-
-    --code-bg-gradient-left: var(--color-green-light);
-    --code-bg-gradient-right: #def3f6;
-    --code-overflow-gradient-left: transparent;
-    --code-overflow-gradient-right: #dff3f4;
-    --code-scrollbar-color: #a3cfd1;
     font-size: 12px;
     line-height: 1.7;
     color: black;
@@ -46,7 +37,7 @@
 }
 
 .content a {
-    color: #0064a4;
+    color: var(--color-blue-medium);
     text-decoration: none;
 }
 
@@ -64,9 +55,7 @@
     color: var(--color-turquoise);
 }
 
-/* Lists
-    '>' selector fixes nested lists
-*/
+/* Lists */
 
 .content ol,
 .content ul {
@@ -87,13 +76,13 @@
 }
 
 .content ul > li::before {
-    content: '';
+    content: '—';
     position: absolute;
     left: 0;
-    top: 0.5em;
-    width: 14px;
-    height: 2px;
-    background-color: var(--list-marker-color);
+    top: -0.4em;
+    bottom: 0;
+    font-size: 21px;
+    color: var(--color-grey-lighter);
 }
 
 /* Ordered Lists */
@@ -115,50 +104,22 @@
     font-size: 21px;
     font-weight: bold;
     line-height: 1.2;
-    color: var(--list-marker-color);
+    color: var(--color-grey-lighter);
 }
 
-/* Картинки */
+/*
+    Картинки
+
+    Основные стили задаются через блок media
+*/
 
 .content img {
-    display: block;
-    width: 100%;
     max-width: 100%;
     height: auto;
-
-    /* set margin for imgs, which doesnt have figure wrapper */
-    margin-top: 16px;
 }
 
-.content img + em,
-.content figcaption {
-    display: block;
-    margin-top: 8px;
-    font-size: 10px;
-    line-height: 1.7;
-    font-style: normal;
-    color: var(--image-caption-color);
-}
-
-.content figure,
-.content .content__image {
-    margin: 0;
+.content figure {
     margin: 32px 0;
-}
-
-.content figure img {
-    /* reset margin when img has figure around it */
-    margin: 0;
-}
-
-/* Increase specificity */
-
-/* .content .content__image--full {
-} */
-
-.content .content__image--align-left,
-.content .content__image--align-right {
-    margin: 16px 0;
 }
 
 /* Цитаты */
@@ -183,24 +144,17 @@
     background-color: var(--color-grey-lighter);
 }
 
-.content blockquote h1 {
-    margin: 0;
-    font-size: inherit;
-    font-weight: inherit;
-    color: inherit;
-}
-
 /* Код */
 
 .content pre {
     position: relative;
     margin: 16px 0;
     padding: 4px 16px;
-    background-color: var(--code-bg-gradient-left);
+    background-color: var(--color-green-light);
     background-image: linear-gradient(
         to right,
-        var(--code-bg-gradient-left) 0%,
-        var(--code-bg-gradient-right) 100%
+        var(--color-green-light) 0%,
+        var(--color-blue-lightest) 100%
     );
 }
 
@@ -213,8 +167,8 @@
     width: 76px;
     background-image: linear-gradient(
         to left,
-        var(--code-overflow-gradient-right) 0%,
-        var(--code-overflow-gradient-left) 100%
+        var(--color-blue-lightest) 0%,
+        transparent 100%
     );
 }
 
@@ -222,6 +176,8 @@
     display: block;
     padding: 16px 0;
     overflow: auto;
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-green-darker) transparent;
 }
 
 .content code::-webkit-scrollbar {
@@ -229,7 +185,7 @@
 }
 
 .content code::-webkit-scrollbar-thumb {
-    background-color: var(--code-scrollbar-color);
+    background-color: var(--color-green-darker);
     border-radius: 24px;
 }
 
@@ -245,22 +201,11 @@
 /* Буквица */
 
 .content > p:first-of-type::first-letter {
+    float: left;
+    padding: 0 5px;
+    font-size: 2em;
     font-family: 'Dewi Expanded';
     color: var(--color-grey-medium);
-}
-
-/* @supports (-webkit-initial-letter: 2) or (initial-letter: 2) {
-    .content > p:first-of-type {
-        initial-letter: 2;
-    }
-} */
-
-@supports not ((-webkit-initial-letter: 2) or (initial-letter: 2)) {
-    .content > p:first-of-type::first-letter {
-        float: left;
-        padding: 0 5px;
-        font-size: 2em;
-    }
 }
 
 

--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -4,6 +4,11 @@
     font-size: 12px;
     line-height: 1.7;
     color: black;
+    box-sizing: border-box;
+}
+
+.content * {
+    box-sizing: inherit;
 }
 
 .content h2,
@@ -37,7 +42,6 @@
 }
 
 .content a {
-    color: var(--color-blue-medium);
     text-decoration: none;
 }
 
@@ -114,6 +118,7 @@
 */
 
 .content img {
+    display: block;
     max-width: 100%;
     height: auto;
 }
@@ -211,13 +216,107 @@
 
 @media (min-width: 1240px) {
     .content {
-        width: 863px;
+        --content-width: 65%;
+        --content-half: calc(var(--content-width) / 2);
+        font-size: 21px;
+    }
+
+    .content.content > * {
+        /* не хватает специфичности, чтобы перебить маргины у элементов */
+        width: var(--content-width);
         margin-left: auto;
     }
-}
 
-@media (min-width: 1500px) {
-    .content {
-        width: 880px;
+    .content h2,
+    .content h3 {
+        margin-top: 60px;
+        margin-bottom: 24px;
+        font-size: 24px;
+    }
+
+    .content p {
+        letter-spacing: 0.03em;
+    }
+
+    .content a {
+        text-decoration: underline;
+    }
+
+    .content ol > li,
+    .content ul > li {
+        padding-left: 43px;
+    }
+
+    .content ul > li::before {
+        left: 6px;
+        top: 0;
+    }
+
+    .content ol > li::before {
+        top: 0.2em;
+    }
+
+    /* Картинки */
+
+    /* Подпись в левой колонке */
+
+    .content .content__media--floated-caption {
+        display: flex;
+        width: 100%;
+    }
+
+    .content__media--floated-caption img {
+        max-width: var(--content-width);
+    }
+
+    .content__media--floated-caption figcaption {
+        order: -1;
+        max-width: 300px;
+        margin-right: auto;
+    }
+
+    /* Картинки с обтеканием текста */
+
+    .content .content__media--align-right {
+        width: var(--content-half);
+        float: right;
+        margin-left: 1em;
+    }
+
+    /* .content__media--align-right + * {
+        clear: both;
+    } */
+
+    /* Картинки на всю ширину */
+
+    .content .content__media--full {
+        width: 100%;
+    }
+
+    .content__media--full figcaption {
+        width: var(--content-width);
+        margin-left: auto;
+    }
+
+    .content blockquote {
+        margin-top: 40px;
+        margin-bottom: 60px;
+        padding-left: 40px;
+        font-size: 32px;
+    }
+
+    .content blockquote::before {
+        width: 4px;
+        top: 0.5em;
+        bottom: 0.5em;
+    }
+
+    .content pre {
+        margin: 60px 0;
+        padding-left: 36px;
+    }
+
+    .content pre code {
+        padding: 32px 0;
     }
 }

--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -206,6 +206,7 @@
 
 .content > p:first-of-type::first-letter {
     float: left;
+    margin: -0.1em 0;
     padding: 0 5px;
     font-size: 2em;
     font-family: 'Dewi Expanded';

--- a/src/styles/blocks/media.css
+++ b/src/styles/blocks/media.css
@@ -1,16 +1,20 @@
-
 .media img {
     display: block;
     width: 100%;
-    max-width: 100%;
     height: auto;
 }
 
 .media figcaption {
     display: block;
-    margin-top: 8px;
+    margin-top: 0.75em;
     font-size: 10px;
     line-height: 1.7;
     font-style: normal;
     color: var(--color-grey-darker);
+}
+
+@media (min-width: 1240px) {
+    .media figcaption {
+        font-size: 16px;
+    }
 }

--- a/src/styles/blocks/media.css
+++ b/src/styles/blocks/media.css
@@ -1,0 +1,16 @@
+
+.media img {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+}
+
+.media figcaption {
+    display: block;
+    margin-top: 8px;
+    font-size: 10px;
+    line-height: 1.7;
+    font-style: normal;
+    color: var(--color-grey-darker);
+}

--- a/src/styles/blocks/media.css
+++ b/src/styles/blocks/media.css
@@ -1,3 +1,10 @@
+.media {
+    margin-top: 32px;
+    margin-bottom: 32px;
+    margin-left: 0;
+    margin-right: 0;
+}
+
 .media img {
     display: block;
     width: 100%;
@@ -14,7 +21,55 @@
 }
 
 @media (min-width: 1240px) {
+    .media {
+        margin-top: 60px;
+        margin-bottom: 60px;
+    }
+
     .media figcaption {
         font-size: 16px;
+    }
+
+    /* Подпись в левой колонке */
+
+    .media--floated-caption {
+        display: flex;
+        width: 100%;
+        margin: 16px 0;
+    }
+
+    .media--floated-caption img {
+        max-width: var(--content-width, 100%);
+    }
+
+    .media--floated-caption figcaption {
+        order: -1;
+        max-width: 300px;
+        margin-right: auto;
+    }
+
+    /* Картинки на всю ширину */
+
+    .media--full {
+        width: 100%;
+    }
+
+    .media--full figcaption {
+        width: var(--content-width, 100%);
+        margin-left: auto;
+    }
+
+    /* Картинки с обтеканием текста */
+
+    .media--align-right {
+        width: var(--content-half, 50%);
+        float: right;
+        margin-top: 1em;
+        margin-left: 1em;
+    }
+
+    .media--align-right + * + * {
+        /* сброс обтекания после блока текста */
+        clear: both;
     }
 }

--- a/src/styles/blocks/page.css
+++ b/src/styles/blocks/page.css
@@ -41,6 +41,7 @@
 
 .page__content {
     display: grid;
+    grid-template-columns: 100%;
     grid-template-rows:
         min-content
         1fr

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -15,6 +15,7 @@
 @import 'blocks/informer.css';
 @import 'blocks/main.css';
 @import 'blocks/content.css';
+@import 'blocks/media.css';
 @import 'blocks/links.css';
 @import 'blocks/footer.css';
 @import 'blocks/article.css';
@@ -38,5 +39,6 @@
     --color-blue-medium: #26649f;
     --color-blue-darker: #0064a4;
     --color-green-light: #ddf2ea;
+    --color-green-darker: #a3cfd1;
     --color-turquoise: #00abbd;
 }


### PR DESCRIPTION
Делает #54

Написал основные стили под 320.
Сейчас есть следующие проблемы:
- Сниппеты кода из-за `white-space: pre` игнорируют ширину, из-за чего растягивается весь контент. Пока не нашел как заставить его подстраиваться под ширину родителя.
- Разметка картинок генерирует `<img> + <em>` вместо `<figure>`
- В задаче упоминаются картинки с обтеканием и на всю ширину, но в статье, по которой сделан макет (война css и js) картинок нет вообще, а в тех, где есть, непонятно где какие.

