### PR TITLE
Правит цвет ссылок карточки статьи на десктопе

### DIFF
--- a/src/styles/blocks/article.css
+++ b/src/styles/blocks/article.css
@@ -171,8 +171,13 @@
         margin: 10% 0 0;
     }
 
-    .article__tags-link {
+    .article__link {
         color: black;
+    }
+
+    .article__link:hover,
+    .article__link:focus {
+        color: var(--color-turquoise);
     }
 }
 


### PR DESCRIPTION
Исправил невидимые ссылки #183 на разрешениях выше `1024px`. При наведении сделал цвет бирюзовый, как у ссылок ниже.
![image](https://user-images.githubusercontent.com/28845333/77528966-e50e5a80-6e9f-11ea-91f7-76603b6249b4.png)
Hover:
![image](https://user-images.githubusercontent.com/28845333/77529024-f5bed080-6e9f-11ea-9255-49f97fb20f6e.png)


